### PR TITLE
Add support for an extra homebridge flag needed by the UI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ homebridge_defaults: /etc/default/homebridge
 homebridge_port: 51826
 # If homebridge should run in debug mode
 homebridge_debug: false
+# Insecure mode toggle needed by the homebridge UI for the accessories view
+homebridge_insecure_mode: false
 # Node.js version to run homebridge under
 homebridge_nodejs_version: "14.x"
 # Path to Node.js

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,6 @@ homebridge_platforms: []
 homebridge_nodejs_binary: /usr/bin/node
 homebridge_nodejs_version: "14.x"
 homebridge_debug: false
+homebridge_insecure_mode: false
 homebridge_systemd_part_of_service:
 homebridge_enable_cap_net_raw: false

--- a/templates/etc/default/homebridge.j2
+++ b/templates/etc/default/homebridge.j2
@@ -1,9 +1,9 @@
 # {{ ansible_managed }}
 
 # The following settings tells homebridge where to find the config.json file and where to persist the data (i.e. pairing and others)
-HOMEBRIDGE_OPTS=-U {{ homebridge_dir }} {% if homebridge_debug %}-D{% endif %}
+HOMEBRIDGE_OPTS={% if homebridge_insecure_mode %}-I{% endif %} -U {{ homebridge_dir }} {% if homebridge_debug %}-D{% endif %}
 
 
-# If you uncomment the following line, homebridge will log more 
+# If you uncomment the following line, homebridge will log more
 # You can display this via systemd's journalctl: journalctl -f -u homebridge
 #DEBUG=*


### PR DESCRIPTION
## Overview
Added support for the `-I` flag in order to support the enabling of the Accessories view in the UI plugin:
https://github.com/oznu/homebridge-config-ui-x#accessory-control

It's a pity that it's needed but I've disabled it by default. 